### PR TITLE
Allow report to be spread across separate files.

### DIFF
--- a/R/report_functions.R
+++ b/R/report_functions.R
@@ -836,7 +836,8 @@ runReport <- function(queryFilePath = 'testdata',
                       outDir = getwd(),
                       printProcessedTables = FALSE,
                       sampleN = 0,
-                      quiet = FALSE) {
+                      quiet = FALSE,
+                      self_contained = TRUE) {
 
   if (genomeVersion == 'hg19') {
     species <- 'human'
@@ -905,7 +906,8 @@ runReport <- function(queryFilePath = 'testdata',
       toc_float = TRUE,
       theme = 'simplex',
       number_sections = TRUE,
-      includes = rmarkdown::includes(in_header = headerFile)
+      includes = rmarkdown::includes(in_header = headerFile),
+      self_contained = self_contained
       ),
     params = list(query = queryFilePath,
                   gff = gffFilePath,


### PR DESCRIPTION
By default, generated HTML reports include all resources as
base64-encoded strings.  To render these self-contained documents in the
browser requires considerable amount of memory on the client.  By
passing `self_contained = FALSE' users can override the default.

I've tested this with the web interface and it makes a big difference in both versions of Firefox I use on two different machines.

Do you prefer `selfContained` (for consistency) or `self_contained`?
